### PR TITLE
主页会预览描述优先显示meta description

### DIFF
--- a/next-mist/index.hbs
+++ b/next-mist/index.hbs
@@ -31,7 +31,11 @@
                          </div>
                      </header>
                      <div class="post-body" itemprop="articleBody">
-                         {{content words="32"}}
+                         {{#if meta_description}}
+                            {{meta_description}}
+                         {{else}}
+                            {{content words="32"}}
+                         {{/if}}
                          <div class="post-more-link text-center">
                              <a class="btn" href="{{url}}" rel="contents">阅读全文 »</a>
                          </div>


### PR DESCRIPTION
主页的文章预览描述现在是content的前32个字，但是代码块并不被计算在其中。大量的代码会破坏掉排版的没关，而且往往不能描述文章的核心内容。
希望改成优先显示meta description，没有description 显示content的前32个字。这样作者可以自由设置文章描述信息，利于读者预览，和界面美观。
